### PR TITLE
[#558] replace app armor annotation with appArmorProfile

### DIFF
--- a/on-premise-docker-registry/k8s/deployment.yaml
+++ b/on-premise-docker-registry/k8s/deployment.yaml
@@ -12,11 +12,12 @@ spec:
   strategy: {}
   template:
     metadata:
-      annotations:
-        container.apparmor.security.beta.kubernetes.io/nginx: runtime/default
       labels:
         app: nginx
     spec:
+      securityContext:
+        appArmorProfile:
+          type: RuntimeDefault
       automountServiceAccountToken: false
       volumes:
         - name: nginx-conf


### PR DESCRIPTION
The
spec.template.metadata.annotations[container.apparmor.security.beta.kubernetes.io/ annotation is deprecated with k8s v.1.30. Instead The AppArmor Profile should be used. See https://kubernetes.io/docs/tutorials/security/apparmor/

Fixes #558

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- use appArmorProfile instead of annotation


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
